### PR TITLE
Balance Changes for v19

### DIFF
--- a/blobs/doctor/doctor.py
+++ b/blobs/doctor/doctor.py
@@ -44,7 +44,7 @@ class Doctor(Blob):
                     skc = bool(self.kick_cooldown > 0)
                     slc = bool(self.block_cooldown > 0)
                     sbc = bool(self.boost_cooldown_timer > 0)
-                    #self.special_ability_cooldown -= 90 * Blob.timer_multiplier
+                    self.special_ability_cooldown -= 90 * Blob.timer_multiplier
                     self.kick_cooldown -= 90 * Blob.timer_multiplier
                     self.block_cooldown -= 90 * Blob.timer_multiplier
                     if(self.boost_cooldown_timer > 0):

--- a/blobs/fisher/init.blob
+++ b/blobs/fisher/init.blob
@@ -16,7 +16,7 @@
     "special_ability_maintenance": 12,
     "special_ability_max": 1800,
     "special_ability_cooldown": 2,
-    "special_ability_delay": 20,
+    "special_ability_delay": 10,
     "special_ability_duration": 0
   },
   "descriptors": {

--- a/blobs/joker/joker.py
+++ b/blobs/joker/joker.py
@@ -221,7 +221,7 @@ class Joker(Blob):
                 card_pos = (self.x_pos + 20, self.y_pos - 225)
             elif(menu_direction == "right"):
                 card_pos = (self.x_pos + 160, self.y_pos - 25)
-            self.status_effects['cards']['joker_particle'] = (card_pos, selected_card)
+            self.status_effects['cards']['joker_particle'] = (card_pos, self.ability_icons[selected_card])
             self.status_effects['menu']['open'] = False
             self.status_effects['cards']['recharge'].add(other_card_1)
             self.status_effects['cards']['recharge'].add(other_card_2)

--- a/blobs/quirkless/quirkless.py
+++ b/blobs/quirkless/quirkless.py
@@ -10,12 +10,17 @@ class Quirkless(Blob):
 
     def boost(self):
         super().boost()
-        self.special_ability_cooldown = self.special_ability_cooldown_max
+        if(self.boost_timer == self.boost_duration):
+            self.special_ability_cooldown = self.special_ability_cooldown_max
 
     def ability(self):
         if(self.special_ability_meter >= self.special_ability_cost and self.special_ability_cooldown <= 0):
             self.boost()
-            self.special_ability_cooldown = self.special_ability_cooldown_max
+            if(self.boost_timer == self.boost_duration):
+                self.special_ability_cooldown = self.special_ability_cooldown_max
+
+    def apply_boost_kick_effect(self, blob):
+        blob.apply_status_effect("silenced", 180, 600, "add")
 
     def reset(self):
         super().reset()

--- a/blobs/random/random.py
+++ b/blobs/random/random.py
@@ -1,8 +1,8 @@
 from engine.blobs.blobs import Blob
 import random
-class Quirkless(Blob):
+class Random(Blob):
     default_stats = {"hp": 8}
-    species = "quirkless"
+    species = "random"
     def __init__(self, x_pos = 50, y_pos = 1200, facing = 'left', player = 1, 
     special_ability_charge_base = 1, costume = 0, danger_zone_enabled = True, is_cpu = False, stat_overrides = [], match_state = None):
         super().__init__(x_pos, y_pos, facing, player, special_ability_charge_base, costume, 

--- a/engine/ball.py
+++ b/engine/ball.py
@@ -710,6 +710,8 @@ class Ball:
                 self.status_effects[effect] -= 1
                 if(self.status_effects["bubbled"] == 0):
                     self.bubble = None
+                    self.x_speed *= 2
+                    self.y_speed *= 2
         
     def update_bubble_status(self, bubble = None, blob = None):
         current_bubble = self.bubble

--- a/engine/blobs/blob_handler.py
+++ b/engine/blobs/blob_handler.py
@@ -26,8 +26,8 @@ class BlobContainer:
 blob_list = BlobContainer()
 #blob_list = BlobContainer().blob_dict
 
-print("~"*100)
-print(blob_list.return_blob_dict())
+#print("~"*100)
+#print(blob_list.return_blob_dict())
 
 
 def get_blob_list():

--- a/engine/blobs/blobs.py
+++ b/engine/blobs/blobs.py
@@ -617,7 +617,7 @@ class Blob:
             
             self.status_effects['taxing'] = self.special_ability_duration
             blob.status_effects['taxed'] = self.special_ability_duration
-            print(self.status_effects['taxing'])
+            #print(self.status_effects['taxing'])
             if(self.species != "king"):
                 self.status_effects['taxing'] = 240
                 blob.status_effects['taxed'] = 240
@@ -735,15 +735,16 @@ class Blob:
                     self.y_pos = Blob.ground
                 teleported = True
                 self.kick(ignore_cooldown=True)
-                createSFXEvent('teleport')
+                create_environmental_modifier(player = self.player, species='sharp_shadow', affects={'enemy'}, lifetime=5, x_pos=self.x_center-20, y_pos=self.y_center-20, hp = 1, special_functions = [create_environmental_modifier])
                 draw_teleportation_pfx([self.x_pos, self.y_pos])
                 #print("teleported to", hazard.x_pos, hazard.y_pos, hazard.species)
-            elif(hazard.player != self.player):
+            elif(hazard.player != self.player and self.player not in hazard.affects):
                 if(self.x_center - 130 <= hazard.x_pos <= self.x_center + 75 and self.y_center - 125 <= hazard.y_pos <= self.y_center + 50):
                     if(self.status_effects['judged'] < 60):
                         self.status_effects['judged'] = 60
                     if(self.status_effects['hypothermia'] < 60):
                         self.status_effects['hypothermia'] = 60#
+                    hazard.affects.add(self.player)
                     #self.take_damage(damage = 0, unblockable=True, unclankable=True, status_effects=[['judged', 60], ['hypothermia', 60]])
         
         for hazard in environment['royal_loan']:
@@ -1349,7 +1350,6 @@ class Blob:
                         self.stars[key] = (stat_overrides[key] - 6)//2
                 else:
                     self.stars[key] = stat_overrides[key]
-                    print(self.stars)
         return self.stars
 
     def set_base_stats(self, stars, set_hp = True, set_ability = True):
@@ -1507,7 +1507,7 @@ class Blob:
             self.sprite_collisions[sprite_tuple] += 1
         else:
             self.sprite_collisions[sprite_tuple] = 1
-        print(self.sprite_collisions)
+        #print(self.sprite_collisions)
         self.ability_icons['default'] = pg.transform.scale(temp_dict['ability'].convert_alpha(), (70, 70))
         return temp_dict
 

--- a/resources/graphics_engine/display_gameplay.py
+++ b/resources/graphics_engine/display_gameplay.py
@@ -67,7 +67,7 @@ def create_ui_icons(ui_font, blob):
     game_display = pg.Surface((390, 70), pg.SRCALPHA)
     ability_icon = blob.ability_icons['default']
     if(blob.status_effects['cards']['ability']):
-        ability_icon = image_cache['icons'][blob.status_effects['cards']['ability']]
+        ability_icon = blob.ability_icons[blob.status_effects['cards']['ability']]
     pg.draw.rect(game_display, (200, 200, 200), (0, 0, 70, 70))
     game_display.blit(image_cache["heart_icon"], (0, 0))
     
@@ -78,21 +78,21 @@ def create_ui_icons(ui_font, blob):
     if(not blob.status_effects['cards']['kick']):
         kick_icon = image_cache["kick_icon"]
     else:
-        kick_icon = image_cache['icons'][blob.status_effects['cards']['kick']]
+        kick_icon = blob.ability_icons[blob.status_effects['cards']['kick']]
     pg.draw.rect(game_display, (200, 200, 200), (160, 0, 70, 70))
     game_display.blit(kick_icon, (160, 0))
     
     if(not blob.status_effects['cards']['block']):
         block_icon = image_cache["block_icon"]
     else:
-        block_icon = image_cache['icons'][blob.status_effects['cards']['block']]
+        block_icon = blob.ability_icons[blob.status_effects['cards']['block']]
     pg.draw.rect(game_display, (200, 200, 200), (240, 0, 70, 70))
     game_display.blit(block_icon, (240, 0))
 
     if(not blob.status_effects['cards']['boost']):
         boost_icon = image_cache["boost_icon"]
     else:
-        boost_icon = image_cache['icons'][blob.status_effects['cards']['boost']]
+        boost_icon = blob.ability_icons[blob.status_effects['cards']['boost']]
     pg.draw.rect(game_display, (200, 200, 200), (320, 0, 70, 70))
     game_display.blit(boost_icon, (320, 0))
 

--- a/resources/graphics_engine/display_particles.py
+++ b/resources/graphics_engine/display_particles.py
@@ -307,7 +307,7 @@ def draw_shatter(align, shatter_timer):
 
 def draw_card_selection(position, icon):
     particle_memory.append(dpc.Particle(image = particle_cache['joker_card'], x_pos = position[0]*(1000/1366), y_pos = position[1]*(382/768), alpha = 255, fade = 1, y_speed = -0.25, lifetime = 300))
-    particle_memory.append(dpc.Particle(image = particle_cache['icons'][icon], x_pos = (position[0]+5)*(1000/1366), y_pos = (position[1]+5)*(382/768), alpha = 255, fade = 1, y_speed = -0.25, lifetime = 300))
+    particle_memory.append(dpc.Particle(image = icon, x_pos = (position[0]+5)*(1000/1366), y_pos = (position[1]+5)*(382/768), alpha = 255, fade = 1, y_speed = -0.25, lifetime = 300))
 
 shop_crop_info = {
         "spring_kick_0": (0,0,60,60),


### PR DESCRIPTION
Doctor Blob's Cooldown Pill now reduces Ability Cooldown by 90 frames (was 0)

Fisher Blob's hook delay is now 10 frames (was 20)

Fixed a crash caused by selecting a card as Joker Blob

Quirkless Blob's Boost Kick now does 180 frames of Silence

Fixed a glitch with the cooldown timer of Quirkless Blob

Bubbles now launch the ball with twice  the force when popped naturally

Arcade Blob's Cartridges now apply hypothermia and c&d once, not repeatedly

Arcade Blob no longer kicks when teleporting, and instead uses sharp shadow, effectively halving the damage